### PR TITLE
avoid metaprogramming for tx creation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules
 
 # Outputs
 dist
+
+# ide
+.idea

--- a/classes/transaction.js
+++ b/classes/transaction.js
@@ -49,22 +49,16 @@ class Transaction {
   }
 
   static fromBuffer (buffer) {
-    let transaction
-    try {
-      if (!isBuffer(buffer)) throw new Error('not a buffer')
-      transaction = decodeTx(buffer)
-    } catch (e) {
-      throw new Error(`Cannot create Transaction: ${e.message}`)
-    }
+    if (!isBuffer(buffer)) throw new Error('not a buffer')
+    const txData = decodeTx(buffer)
 
-    Object.setPrototypeOf(transaction, Transaction.prototype)
-    transaction.inputs.forEach(input => Object.setPrototypeOf(input, Input.prototype))
-    transaction.inputs.forEach(input => { input.script = Script.fromBuffer(input.script) })
-    transaction.outputs.forEach(output => Object.setPrototypeOf(output, Output.prototype))
-    transaction.outputs.forEach(output => { output.tx = this })
-    transaction.outputs.forEach(output => { output.script = Script.fromBuffer(output.script) })
+    const tx = new this()
+    txData.inputs.forEach(inp => tx.input(inp))
+    txData.outputs.forEach(out => tx.output(out))
+    tx.locktime = txData.locktime
+    tx.version = txData.version
 
-    return transaction
+    return tx
   }
 
   toHex () {

--- a/test/classes/transaction.js
+++ b/test/classes/transaction.js
@@ -51,7 +51,7 @@ describe('Transaction', () => {
 
     it('throws if invalid', () => {
       const badHex = new Transaction().toString() + '00'
-      expect(() => Transaction.fromHex(badHex)).to.throw('Cannot create Transaction: unconsumed data')
+      expect(() => Transaction.fromHex(badHex)).to.throw('unconsumed data')
     })
   })
 
@@ -64,7 +64,7 @@ describe('Transaction', () => {
 
     it('throws if invalid', () => {
       const badHex = '00' + new Transaction().toString()
-      expect(() => Transaction.fromHex(badHex)).to.throw('Cannot create Transaction: unconsumed data')
+      expect(() => Transaction.fromHex(badHex)).to.throw('unconsumed data')
     })
   })
 
@@ -92,12 +92,12 @@ describe('Transaction', () => {
 
     it('throws if not a buffer', () => {
       const hex = new Transaction().toString()
-      expect(() => Transaction.fromBuffer(hex)).to.throw('Cannot create Transaction: not a buffer')
+      expect(() => Transaction.fromBuffer(hex)).to.throw('not a buffer')
     })
 
     it('throws if invalid', () => {
       const badBuffer = [0].concat(Array.from(new Transaction().toBuffer()))
-      expect(() => Transaction.fromBuffer(badBuffer)).to.throw('Cannot create Transaction: unconsumed data')
+      expect(() => Transaction.fromBuffer(badBuffer)).to.throw('unconsumed data')
     })
 
     it('creates script objects', () => {


### PR DESCRIPTION
The tx object has everything needed to avoid having to do metaprogramming to create a new tx object. Because the buffers are not copied the amount of memory used is basially the same.

also, I removed the try catch inside the `toBuffer`, because it was enmascarating errors. Basically by transforming everything into an `Error` is hard to handle speific situations.