### PR TITLE
allow setting the feePerKb value on a per tx basis

### DIFF
--- a/classes/transaction.js
+++ b/classes/transaction.js
@@ -29,6 +29,7 @@ class Transaction {
     this.inputs = []
     this.outputs = []
     this.locktime = 0
+    this.feePerKb = require('../index').feePerKb;
 
     // An actual output object matching an entry in this.outputs
     this.changeOutput = undefined
@@ -231,7 +232,7 @@ class Transaction {
     this.changeOutput.satoshis = 0
 
     const currentFee = this.fee
-    const expectedFee = Math.ceil(encodeTx(this).length * require('../index').feePerKb / 1000)
+    const expectedFee = Math.ceil(encodeTx(this).length * this.feePerKb / 1000)
 
     const change = currentFee - expectedFee
     const minDust = 1
@@ -242,6 +243,16 @@ class Transaction {
       this.outputs.splice(changeIndex, 1)
       this.changeOutput = undefined
     }
+  }
+
+  setFeePerKb (satoshis) {
+    if (Object.isFrozen(this)) throw new Error('transaction finalized')
+
+    verifySatoshis(satoshis)
+
+    this.feePerKb = satoshis
+
+    return this
   }
 }
 

--- a/test/classes/transaction.js
+++ b/test/classes/transaction.js
@@ -595,4 +595,23 @@ describe('Transaction', () => {
       expect(tx.changeOutput).to.equal(undefined)
     })
   })
+
+  describe('feePerKb', () => {
+    it('change the feePerKb', () => {
+      const tx = new Transaction().setFeePerKb(0)
+      const tx2 = new Transaction()
+      const bsvTx = new bsv.Transaction()
+      bsvTx.feePerKb = 0
+
+      expect(tx.feePerKb).to.equal(bsvTx.feePerKb)
+      expect(tx.feePerKb).to.not.equal(tx2.feePerKb)
+      expect(tx.feePerKb).to.equal(0)
+      expect(tx2.feePerKb).to.equal(nimble.feePerKb)
+    })
+
+    it('throws if invalid', () => {
+      expect(() => new Transaction().setFeePerKb(-1)).to.throw('bad satoshis: -1')
+      expect(() => new Transaction().finalize().setFeePerKb(-1)).to.throw('transaction finalized')
+    })
+  })
 })


### PR DESCRIPTION
optionally use a local feePerKb value instead of the global nimble one