### PR TITLE
make async boolean implicit facultative (default: false)

### DIFF
--- a/functions/preimage.js
+++ b/functions/preimage.js
@@ -6,7 +6,7 @@ const decodeHex = require('./decode-hex')
 const sha256d = require('./sha256d')
 const sha256Async = require('./sha256-async')
 
-function preimage (tx, vin, parentScript, parentSatoshis, sighashFlags, async) {
+function preimage (tx, vin, parentScript, parentSatoshis, sighashFlags, async = false) {
   const input = tx.inputs[vin]
   const outputs = tx.outputs || []
 

--- a/functions/sighash.js
+++ b/functions/sighash.js
@@ -3,7 +3,7 @@ const preimageAsync = require('./preimage-async')
 const sha256d = require('./sha256d')
 const sha256Async = require('./sha256-async')
 
-function sighash (tx, vin, parentScript, parentSatoshis, sighashFlags, async) {
+function sighash (tx, vin, parentScript, parentSatoshis, sighashFlags, async = false) {
   if (async) {
     return preimageAsync(tx, vin, parentScript, parentSatoshis, sighashFlags)
       .then(sha256Async)


### PR DESCRIPTION
The functions can be called without defining the async parameter (null).
By defining a default value it is clearer that this is the case.